### PR TITLE
Buffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "author": {
     "name": "Tim Hudson",
     "email": "tim.hudson15@gmail.com"
+  },
+  "dependencies": {
+    "buffertools": "^2.1.2"
   }
 }


### PR DESCRIPTION
This was benchmarked and the performance isn't great:

> buffers x 0.08 ops/sec ±1.08% (5 runs sampled)
> strings x 0.14 ops/sec ±0.59% (5 runs sampled)

Memory usage was better but not significantly. I'm tempted to just stick with manipulating strings for now.

Here is the benchmark I was using: https://gist.github.com/timhudson/674aa868b7aac7785285
