### PR TITLE
fix issue with multiple nested items

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,17 +46,20 @@ XmlNodes.prototype.getNodes = function(nodes) {
 
 XmlNodes.prototype.getNestedCount = function(str) {
   var openingIndex = this.getOpeningIndex(str)
-    , firstClosingIndex = str.indexOf('</'+this.nodeName+'>')
+    , closingIndex = str.indexOf('</'+this.nodeName+'>')
     , currentIndex = openingIndex + 1
     , count = 0
 
-  if (!firstClosingIndex) return false
+  if (!closingIndex) return false
 
-  while (currentIndex < firstClosingIndex) {
+  while (currentIndex < closingIndex) {
     currentIndex = this.getOpeningIndex(str, currentIndex + 1)
 
     if (currentIndex === -1) break
-    if (currentIndex < firstClosingIndex) count++
+    if (currentIndex < closingIndex) {
+      count++
+      closingIndex = this.getClosingIndex(str, count)
+    }
   }
 
   return count

--- a/test/nested.xml
+++ b/test/nested.xml
@@ -19,9 +19,18 @@
 </item>
 <item>
   <title>Al-Jazeera America prepares for Tuesday launch</title>
-  <item>
     <item>Look at me, I'm hella nested!</item>
-  </item>
+</item>
+<item>
+  <title>Al-Jazeera America prepares for Tuesday launch</title>
+    <item>Look at me, I'm hella nested!</item>
+    <item>Look at me, I'm hella nested!</item>
+    <item>Look at me, I'm hella nested!</item>
+    <item>
+      <item>Look at me, I'm hella nested!</item>
+      <item>Look at me, I'm hella nested!</item>
+    </item>
+    <item>Look at me, I'm hella nested!</item>
 </item>
 </channel>
 </rss>

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ var test = require('tap').test
 
 test('xmlNodes', function(t) {
   var count = 0
-  
+
   t.plan(1)
 
   fs.createReadStream(__dirname + '/mrss.xml')
@@ -19,7 +19,7 @@ test('xmlNodes', function(t) {
 })
 
 test('nested nodes', function(t) {
-  t.plan(2)
+  t.plan(3)
 
   fs.createReadStream(__dirname + '/nested.xml')
     .pipe(xmlNodes('item'))


### PR DESCRIPTION
Hello!

There seems to be a issue when more than one item is nested.

For example:

```xml
<item>
  <title>something</title>
  <item>nested item 0ne</item>
  <item>nested item two</item>
</item>
```

This PR will update the `closingIndex` to grab the next occurrence if another openingIndex is detected.